### PR TITLE
Update deployment.yaml -  missing ssh username

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -90,6 +90,11 @@ spec:
               value: "false"
             - name: PASSWORD_ACCESS
               value: "true"
+            - name: USER_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: ssh-sec
+                  key: USER_NAME
             - name: USER_PASSWORD
               valueFrom: 
                 secretKeyRef:


### PR DESCRIPTION
Not adding this env var makes the ssh server use the default username instead of the one set in secrets.yaml